### PR TITLE
fix parsing

### DIFF
--- a/stlc.makam
+++ b/stlc.makam
@@ -20,8 +20,8 @@ eval (lam T F) (lam T F).
 eval (app E E') V'' :- eval E (lam _ F), eval E' V', eval (F V') V''.
 
 %open syntax.
-styp : syntax typ.
-sterm : syntax term.
+styp, styp_base : syntax typ.
+sterm, sterm_base : syntax term.
 sterm_concrete : syntax (concrete term).
 
 termvars: concrete.namespace term.
@@ -29,26 +29,42 @@ concrete.pick_namespace_userdef (_: term) termvars.
 
 tint : typ.
 
-`( syntax_rules {{
-
-styp -> arrow { <styp> "->" <styp> }
-     / tint { "int" }
-
 % longform syntax is here:
 %  fun t1 => fun t2 => app t1 t2 { "@" <sterm> <sterm> }
 
-sterm -> app { "@" <sterm> <sterm> }
-       / fun x => concrete.var (concrete.name termvars x) { <makam.ident> }
+`( syntax_rules {{
+
+styp -> arrow { <styp_base> "->" <styp> }
+      / { <styp_base> }
+
+styp_base -> tint { "int" }
+      / { "(" <styp> ")" }
+
+sterm -> app { <sterm_base> <sterm> }
+       / { <sterm_base> }
+
+sterm_base ->
+         fun x => concrete.var (concrete.name termvars x) { <makam.ident> }
        / fun id => fun tp => fun tm => lam tp (concrete.lambda (concrete.name termvars id) tm) { "λ" <makam.ident> ":" <styp> "." <sterm> }
+       / { "(" <sterm> ")" }
 
 sterm_concrete -> concrete { <sterm> }
 
 }} ).
 
 `( syntax.def_toplevel_js sterm_concrete ).
+`( syntax.def_toplevel_js styp ).
 
-isocast {{ λx: int.x }} (T: term) ?
+tests : testsuite. %testsuite tests.
 
+(isocast {{ λx: int.x }} (E: term), typeof E T) ?
+>> Yes:
+>> E := lam tint (fun x => x),
+>> T := arrow tint tint.
+
+isocast (arrow tint tint) (X: string) ?
+>> Yes:
+>> X := "int -> int ".
 
 %  typeof (lam _ (fun x => x)) T ?
 %  >> Yes:

--- a/stlc.makam
+++ b/stlc.makam
@@ -62,6 +62,11 @@ tests : testsuite. %testsuite tests.
 >> E := lam tint (fun x => x),
 >> T := arrow tint tint.
 
+(isocast {{ λf: int -> int.λx: int.f x }} (_E: term), typeof _E _T, isocast _T (X: string)) ?
+>> Yes:
+>> X := "( int -> int ) -> int -> int ".
+
+
 isocast (arrow tint tint) (X: string) ?
 >> Yes:
 >> X := "int -> int ".


### PR DESCRIPTION
@d4hines 
Fixes parsing for STLC. Main issue was that we included a comment within the syntax definitions (noted that as an issue). Also split things up into two precedence levels so that the syntax is more normal-looking!

One issue you might run into with pretty-printing is that only fully concrete terms and types can be pretty-printed, that do not contain uninstantiated unification variables. Same with parsing: the parsing rules as written cannot parse "missing information", e.g. something like `λx:T.x` where `T` becomes a Makam-level unification variable.


